### PR TITLE
#40 backend mods

### DIFF
--- a/packages/daemon/src/InstanceManager.ts
+++ b/packages/daemon/src/InstanceManager.ts
@@ -11,6 +11,8 @@ import {
   DAEMON_PB_PASSWORD,
   DAEMON_PB_PORT_BASE,
   DAEMON_PB_USERNAME,
+  PUBLIC_APP_DOMAIN,
+  PUBLIC_APP_PROTOCOL,
   PUBLIC_PB_DOMAIN,
   PUBLIC_PB_PROTOCOL,
   PUBLIC_PB_SUBDOMAIN,
@@ -142,11 +144,16 @@ export const createInstanceManger = async () => {
 
       console.log(`Checking ${subdomain} for permission`)
 
-      const recs = await client.getInstanceBySubdomain(subdomain)
-      const [instance] = recs.items
+      const [instance, owner] = await client.getInstanceBySubdomain(subdomain)
       if (!instance) {
         console.log(`${subdomain} not found`)
         return
+      }
+
+      if (!owner?.verified) {
+        throw new Error(
+          `Log in at ${PUBLIC_APP_PROTOCOL}://${PUBLIC_APP_DOMAIN} to verify your account.`
+        )
       }
 
       await client.updateInstanceStatus(subdomain, InstanceStatus.Port)
@@ -162,6 +169,7 @@ export const createInstanceManger = async () => {
       console.log(`Found port for ${subdomain}: ${newPort}`)
 
       await client.updateInstanceStatus(subdomain, InstanceStatus.Starting)
+
       const childProcess = await _spawn({
         subdomain,
         port: newPort,

--- a/packages/daemon/src/ProxyServer.ts
+++ b/packages/daemon/src/ProxyServer.ts
@@ -18,23 +18,21 @@ export const createProxyServer = async () => {
       })
       res.end(msg)
     }
+
     const host = req.headers.host
     if (!host) {
-      die(`Host not found`)
-      return
+      throw new Error(`Host not found`)
     }
     const [subdomain, ...junk] = host.split('.')
     if (!subdomain) {
-      die(`${host} has no subdomain.`)
-      return
+      throw new Error(`${host} has no subdomain.`)
     }
     try {
       const instance = await instanceManager.getInstance(subdomain)
       if (!instance) {
-        die(
+        throw new Error(
           `${host} not found. Please check the instance URL and try again, or create one at ${PUBLIC_APP_PROTOCOL}://${PUBLIC_APP_DOMAIN}.`
         )
-        return
       }
 
       console.log(

--- a/packages/pockethost.io/src/pocketbase/PocketbaseClient.ts
+++ b/packages/pockethost.io/src/pocketbase/PocketbaseClient.ts
@@ -1,5 +1,10 @@
-import type { InstanceId, Instance_In, Instance_Out } from '@pockethost/common'
-import { createRealtimeSubscriptionManager } from '@pockethost/common'
+import {
+  assertExists,
+  createRealtimeSubscriptionManager,
+  type InstanceId,
+  type Instance_In,
+  type Instance_Out
+} from '@pockethost/common'
 import { keys, map } from '@s-libs/micro-dash'
 import PocketBase, { BaseAuthStore, ClientResponseError, Record } from 'pocketbase'
 import type { Unsubscriber } from 'svelte/store'
@@ -80,6 +85,12 @@ export const createPocketbaseClient = (url: string) => {
     return map(e.data.data, (v, k) => (v ? v.message : undefined)).filter((v) => !!v)
   }
 
+  const resendVerificationEmail = async () => {
+    const user = client.authStore.model
+    assertExists(user, `Login required`)
+    await client.users.requestVerification(user.email)
+  }
+
   return {
     parseError,
     subscribe,
@@ -94,6 +105,7 @@ export const createPocketbaseClient = (url: string) => {
     refreshUserData,
     watchInstanceById,
     getAllInstancesById,
-    setInstance
+    setInstance,
+    resendVerificationEmail
   }
 }

--- a/packages/pockethost.io/src/util/database.ts
+++ b/packages/pockethost.io/src/util/database.ts
@@ -174,8 +174,12 @@ export const handleInstanceGeneratorWidget = async (
   }
 }
 
-export const handleResendVerificationEmail = () => {
-  alert('Email sent')
+export const handleResendVerificationEmail = async (setError = (value: string) => {}) => {
+  try {
+    await client.resendVerificationEmail()
+  } catch (error: any) {
+    handleFormError(error, setError)
+  }
 }
 
 export const handleLogout = () => {

--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,10 @@ open https://pockethost.io
 
 # Release History
 
+**next**
+
+- [x] Accounts must now be verified before running an instance
+
 **0.3.1**
 
 - [x] OpenGraph support


### PR DESCRIPTION
Okay I have the backend working for this. 

Something to consider adding to your resend flow:
* Resend error
* Resend succeeded, but offer to send again

You can test both of these using the updated function:

```ts
export const handleResendVerificationEmail = async (setError = (value: string) => {}) => {
  try {
    await client.resendVerificationEmail()
  } catch (error: any) {
    handleFormError(error, setError)
  }
}
```

Success returns nothing (ie, the verification email has been sent and is hopefully in their inbox), but a failure (rare) using that `setError` strategy we are using for other forms. Do with it what you feel is right.

I think the most common experience will be that they press the Resend button and expect something to happen like `Email sent! Go check your inbox. Need to resend?`.

The second most common is they click Resend and never get an email.

Covering both of those cases a little more explicitly would be helpful.

On the backend, it now refuses to launch instances unless `user.verified===true`. It will 403 and tell them to go log in and verify first.